### PR TITLE
Update Cargo.toml fix field name to be repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "Suricata Rule Manager"
 rust-version = "1.82.0"
 homepage = "https://github.com/jasonish/suricasta-rules"
-repo = "https://github.com/jasonish/suricasta-rules"
+repository = "https://github.com/jasonish/suricasta-rules"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive", "color"] }


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is the correct one  More explanation https://github.com/szabgab/rust-digger/issues/91